### PR TITLE
No only in tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,10 @@ module.exports = {
     }],
     "jsx-a11y/label-has-for": "off", // Deprecated and broken in eslint 6.1.0 Airbnb uses label- has - associated - control instead
     "operator-linebreak": ["error", "after"],
+    "no-only-tests/no-only-tests": "error" // Do not allow .only in test files
   },
-  plugins: ["compat"]
+  plugins: [
+    "compat",
+    "no-only-tests"
+  ]
 };

--- a/package.json
+++ b/package.json
@@ -16,13 +16,21 @@
     "eslint-plugin-compat": "^2.1.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
+    "eslint-plugin-no-only-tests": "^2.3.1",
     "eslint-plugin-react": "^7.11.1"
   },
   "devDependencies": {
     "eslint": "^4.16.0"
   },
   "peerDependencies": {
-    "eslint": "^4.16.0"
+    "eslint": ">= 4",
+    "eslint-config-airbnb": ">= 17",
+    "eslint-plugin-compat": ">= 2",
+    "eslint-plugin-graphql": ">= 2",
+    "eslint-plugin-import": ">= 2",
+    "eslint-plugin-jsx-a11y": ">= 6",
+    "eslint-plugin-no-only-tests": ">= 2",
+    "eslint-plugin-react": ">= 7"
   },
   "scripts": {
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-twig",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Twig Education ESLint Config",
   "keywords": [
     "javascript",

--- a/yarn.lock
+++ b/yarn.lock
@@ -482,6 +482,11 @@ eslint-plugin-jsx-a11y@^6.0.3:
     has "^1.0.3"
     jsx-ast-utils "^2.0.1"
 
+eslint-plugin-no-only-tests@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.3.1.tgz#7b24a4df55b818d0838410aa96b24a5a4a072262"
+  integrity sha512-LzCzeQrlkNjEwUWEoGhfjz+Kgqe0080W6qC8I8eFwSMXIsr1zShuIQnRuSZc4Oi7k1vdUaNGDc+/GFvg6IHSHA==
+
 eslint-plugin-react@^7.11.1:
   version "7.12.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz#b1ecf26479d61aee650da612e425c53a99f48c8c"


### PR DESCRIPTION
The `pre-push.sh` script only checks `.jsx` files. This is a better-tested solution, and prevents the same script being copied to every MFE. Pushes to remote will still fail if `.only` is present, now even in `.js` files.